### PR TITLE
Specify port

### DIFF
--- a/dockerdb/__init__.py
+++ b/dockerdb/__init__.py
@@ -131,7 +131,7 @@ class Mongo(Service):
 
         server = self.ip_address()
         return pymongo.MongoClient(
-            server, self.mongo_port, socketTimeoutMS=100, connectTimeoutMS=100)
+            server, self.port, socketTimeoutMS=100, connectTimeoutMS=100)
 
     def factory_reset(self):
         """factory reset the database"""

--- a/dockerdb/__init__.py
+++ b/dockerdb/__init__.py
@@ -102,10 +102,13 @@ class HTTPServer(Service):
 
 class Mongo(Service):
     name = 'mongo'
-    port = 27017
+    mongo_port = 27017
 
-    def __init__(self, tag, wait=False, **kwargs):
-        Service.__init__(self, 'mongo:' + tag)
+    def __init__(self, tag, wait=False, port=27017, **kwargs):
+        self.port = port
+
+        ports = {'{}/tcp'.format(self.mongo_port): ('127.0.0.1', self.port)}
+        Service.__init__(self, 'mongo:' + tag, ports=ports)
         if wait:
             self.wait()
 
@@ -127,8 +130,8 @@ class Mongo(Service):
         import pymongo.errors
 
         server = self.ip_address()
-        return pymongo.MongoClient(server, self.port, socketTimeoutMS=100,
-                                                      connectTimeoutMS=100)
+        return pymongo.MongoClient(
+            server, self.mongo_port, socketTimeoutMS=100, connectTimeoutMS=100)
 
     def factory_reset(self):
         """factory reset the database"""

--- a/dockerdb/pytest.py
+++ b/dockerdb/pytest.py
@@ -31,13 +31,14 @@ def get_service(version):
     return service
 
 
-def ensure_service(version):
+def ensure_service(version, port):
     if version not in CONTAINER_CACHE:
-        CONTAINER_CACHE[version] = dockerdb.Mongo(version, wait=False)
+        CONTAINER_CACHE[version] = dockerdb.Mongo(
+            version, wait=False, port=port)
 
 
 def mongo_fixture(scope='function', versions=['latest'], data=None,
-                  restore=None, reuse=True):
+                  restore=None, reuse=True, port=27017):
     """create ficture for py.test
 
     Attributes:
@@ -61,14 +62,14 @@ def mongo_fixture(scope='function', versions=['latest'], data=None,
     # parallelized start of different versions
     if reuse:
         for version in versions:
-            ensure_service(version)
+            ensure_service(version, port)
 
     @pytest.fixture(scope=scope,  params=versions)
     def mongo(request):
         if reuse:
             service = get_service(request.param)
         else:
-            service = dockerdb.Mongo(request.param, wait=True)
+            service = dockerdb.Mongo(request.param, wait=True, port=port)
         client = service.pymongo_client()
 
         if data:


### PR DESCRIPTION
Enables to specify the port for mongo. Needed for macOS, otherwise the default mongo service needs to be stopped for pytests.

Implementation up for discussion.