### PR TITLE
Timeouts via constructor part2

### DIFF
--- a/dockerdb/mongo_pytest.py
+++ b/dockerdb/mongo_pytest.py
@@ -59,6 +59,7 @@ def mongo_fixture(scope='function', versions=['latest'], data=None,
         restore (str): path to directory containing a mongo dump
         reuse (bool): wether to reuse containers or create a new container
             for every requested injection
+        client_args(dict): arguments that get passed to the pymongo client
 
     """
 


### PR DESCRIPTION
The client_args can now be passed via the mongo fixture